### PR TITLE
Adding conventional slack webhook url

### DIFF
--- a/tf/modules/aws_lambda_tools/locals_conventional.tf
+++ b/tf/modules/aws_lambda_tools/locals_conventional.tf
@@ -1,0 +1,7 @@
+# Inputs that are created by other terraform modules that we're using 
+# because the names are conventional.
+
+locals {
+    # Created by coreinfra
+    conventional_slack_cd_webhook_url_parameterstore_path = "/coreinfra/shared/slack_cd_webhook_url"
+}

--- a/tf/modules/aws_lambda_tools/slack_notification.tf
+++ b/tf/modules/aws_lambda_tools/slack_notification.tf
@@ -1,7 +1,7 @@
 # Check if Slack CD webhook exists in Parameter Store
 data "aws_ssm_parameter" "slack_cd_webhook" {
   count = 1
-  name  = "/coreinfra/shared/slack_cd_webhook_url"
+  name  = local.conventional_slack_cd_webhook_url_parameterstore_path
   
   # Continue even if parameter doesn't exist
   lifecycle {

--- a/tf/modules/github_ci/locals_conventional.tf
+++ b/tf/modules/github_ci/locals_conventional.tf
@@ -2,6 +2,6 @@
 # because the names are conventional.
 
 locals {
-    # Created by coreinfra (github.com/mission-tech/coreinfra
+    # Created by coreinfra (github.com/mission-tech/coreinfra)
     conventional_github_oidc_provider_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com"
 }

--- a/tf/modules/iac_cd/locals_conventional.tf
+++ b/tf/modules/iac_cd/locals_conventional.tf
@@ -30,5 +30,4 @@ locals {
     
     # KMS key name created by coreinfra in tools account
     conventional_pipeline_kms_key_name = "${var.org}-coreinfra-tools-pipeline-artifacts"
-    conventional_pipeline_kms_key_alias = "alias/${local.conventional_pipeline_kms_key_name}"
 }


### PR DESCRIPTION
To prevent every module from needing to populate it.

And removing an unused conventional alias.